### PR TITLE
Feature/genserver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 gen_*.go
+.vscode/

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -2,9 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/Wuvist/go-thrift/parser"
+	"github.com/ezbuy/ezrpc/global"
 	"github.com/ezbuy/ezrpc/langs"
 	_ "github.com/ezbuy/ezrpc/langs/csharp" // fullfill langs
 	_ "github.com/ezbuy/ezrpc/langs/go"
@@ -31,6 +34,16 @@ var genCmd = &cobra.Command{
 			return
 		}
 
+		// initialize global variables here
+
+		a, err := filepath.Abs(input)
+		if err != nil {
+			log.Fatalf("failed to get absoulte path of input file %q: %s", input, err.Error())
+		}
+
+		global.InputFile = a
+		global.IsGenSrvRecursive = genSrvRecursive
+
 		p := &parser.Parser{}
 		parsedThrift, _, err := p.ParseFile(input)
 		if err != nil {
@@ -52,9 +65,16 @@ var genCmd = &cobra.Command{
 
 var lang, input, output string
 
+// when a thrift includes other thrifts, if we generate all service as server,
+// we may encounter problem such as compile error due to lack of structs.
+// so in the minimum, we should only generate server & structs specified to the thrift itself
+var genSrvRecursive bool
+
 func init() {
 	genCmd.PersistentFlags().StringVarP(&lang, "lang", "l", "", "language: go | csharp")
 	genCmd.PersistentFlags().StringVarP(&input, "input", "i", "", "input file")
 	genCmd.PersistentFlags().StringVarP(&output, "output", "o", "", "output path")
+	genCmd.PersistentFlags().BoolVarP(&genSrvRecursive, "srvRecursive", "R", true, "recursivly generate or not")
+
 	RootCmd.AddCommand(genCmd)
 }

--- a/example/Item.thrift
+++ b/example/Item.thrift
@@ -1,0 +1,5 @@
+namespace go item
+
+service Item {
+	void SayHi();
+}

--- a/example/Product.thrift
+++ b/example/Product.thrift
@@ -1,6 +1,8 @@
 namespace go product
 namespace csharp Zen.DataAccess.Product
 
+include "Item.thrift"
+
 struct TShippingFee {
 	1:required string warehouse;	//仓库
 	2:required double fee;			//运费

--- a/global/variables.go
+++ b/global/variables.go
@@ -1,0 +1,6 @@
+package global
+
+var (
+	IsGenSrvRecursive bool
+	InputFile         string
+)

--- a/langs/go/gen_go.go
+++ b/langs/go/gen_go.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Wuvist/go-thrift/parser"
+	"github.com/ezbuy/ezrpc/global"
 	"github.com/ezbuy/ezrpc/langs"
 )
 
@@ -77,6 +78,10 @@ func (this *GoGen) Generate(output string, parsedThrift map[string]*parser.Thrif
 
 	fmt.Println("##### Parsing:")
 	for filename, parsed := range parsedThrift {
+		if !global.IsGenSrvRecursive && filename != global.InputFile {
+			continue
+		}
+
 		fmt.Printf("%s\n", filename)
 		namespace := getNamespace(parsed.Namespaces)
 		importPath, _ := genNamespace(namespace)

--- a/makefile
+++ b/makefile
@@ -8,7 +8,6 @@ init:
 	go get github.com/jteeuwen/go-bindata/...
 
 buildtpl:
-	rm tmpl/bindata.go
 	go-bindata -o tmpl/bindata.go -ignore bindata.go -pkg tmpl tmpl/...
 
 gencsharp: buildtpl


### PR DESCRIPTION
when a thrift includes other thrifts, if we generate all service as server,
we may encounter problem such as compile error due to lack of structs.
so in the minimum, we should only generate server & struct specified to the thrift itself
